### PR TITLE
Console Color Changes (Revert/Fix #1520)

### DIFF
--- a/PoGo.Necrobot.Window/MainClientWindow.xaml
+++ b/PoGo.Necrobot.Window/MainClientWindow.xaml
@@ -152,6 +152,7 @@
                 </StackPanel>
 
             </Button>
+            <ComboBox x:Name="ConsoleThemer" IsEditable="False" IsReadOnly="True" SelectionChanged="ConsoleThemer_SelectionChanged" Background="{x:Null}" BorderBrush="{x:Null}" Width="120" ToolTip="Set Console Colors" />
             <Button Click="MenuSetting_Click" Name="menuSetting">
                 <StackPanel Orientation="Horizontal">
                     <Rectangle Width="20"
@@ -365,9 +366,7 @@
                 <DockPanel LastChildFill="True">
                     <TextBox HorizontalAlignment="Stretch" 
                              Name="txtCmdInput" 
-                             Background="#002b36" 
                              DockPanel.Dock="Top"
-                             Foreground="#fdf6e3" 
                              BorderBrush="Aquamarine" 
                              BorderThickness="1" 
                              ToolTip="{Binding Source=InputCommand, Converter={StaticResource ResourceKey=I18NConveter}}" 
@@ -382,7 +381,6 @@
                     DockPanel.Dock="Top"
                     x:Name="consoleLog"
                     HorizontalAlignment="Stretch"
-                    Background="#002b36"
                     VerticalAlignment="Stretch"
                     FontSize="15" 
                     IsReadOnly="True" 

--- a/PoGo.Necrobot.Window/MainClientWindow.xaml.cs
+++ b/PoGo.Necrobot.Window/MainClientWindow.xaml.cs
@@ -23,6 +23,7 @@ using System.Net.Http;
 using PoGo.NecroBot.Logic;
 using PoGo.NecroBot.Logic.Model.Settings;
 using static PoGo.NecroBot.Logic.MultiAccountManager;
+using System.Windows.Media;
 
 namespace PoGo.Necrobot.Window
 {
@@ -31,29 +32,56 @@ namespace PoGo.Necrobot.Window
     /// </summary>
     public partial class MainClientWindow : MetroWindow
     {
-        private static Dictionary<LogLevel, string> ConsoleColors = new Dictionary<LogLevel, string>()
+        private static Dictionary<LogLevel, string> DefaultConsoleColors = new Dictionary<LogLevel, string>()
             {
-                { LogLevel.Error, "#dc322f" },
-                { LogLevel.Caught, "#859900" },
-                { LogLevel.Info, "#268bd2" } ,
-                { LogLevel.Warning, "#b58900" } ,
-                { LogLevel.Pokestop, "#2aa198" }  ,
-                { LogLevel.Farming, "#d33682" },
-                { LogLevel.Sniper, "#93a1a1" },
-                { LogLevel.Recycling, "#cb4b16" },
-                { LogLevel.Flee, "#b58900" },
-                { LogLevel.Transfer, "#586e75" },
-                { LogLevel.Evolve, "#586e75" },
-                { LogLevel.Berry, "#b58900" },
-                { LogLevel.Egg, "#b58900" },
-                { LogLevel.Debug, "#2aa198" },
-                { LogLevel.Update, "#fdf6e3" },
-                { LogLevel.New, "#859900" },
-                { LogLevel.SoftBan, "#dc322f" },
-                { LogLevel.LevelUp, "#d33682" },
-                { LogLevel.Gym, "#d33682" },
-                { LogLevel.Service , "#fdf6e3" }
+                { LogLevel.Error, "Red" },
+                { LogLevel.Caught, "Green" },
+                { LogLevel.Info, "DarkCyan" } ,
+                { LogLevel.Warning, "DarkYellow" } ,
+                { LogLevel.Pokestop, "Cyan" }  ,
+                { LogLevel.Farming, "Magenta" },
+                { LogLevel.Sniper, "White" },
+                { LogLevel.Recycling, "DarkMagenta" },
+                { LogLevel.Flee, "DarkYellow" },
+                { LogLevel.Transfer, "DarkGreen" },
+                { LogLevel.Evolve, "DarkGreen" },
+                { LogLevel.Berry, "DarkYellow" },
+                { LogLevel.Egg, "DarkYellow" },
+                { LogLevel.Debug, "Gray" },
+                { LogLevel.Update, "White" },
+                { LogLevel.New, "Green" },
+                { LogLevel.SoftBan, "Red" },
+                { LogLevel.LevelUp, "Magenta" },
+                { LogLevel.Gym, "Magenta" },
+                { LogLevel.Service , "White" }
             };
+        private static Dictionary<LogLevel, string> SolarizedConsoleColors = new Dictionary<LogLevel, string>()
+        {
+                { LogLevel.Error, "#DC322F" },
+                { LogLevel.Caught, "#859900" },
+                { LogLevel.Info, "#CB4B16" } ,
+                { LogLevel.Warning, "#B58900" } ,
+                { LogLevel.Pokestop, "#2AA198" }  ,
+                { LogLevel.Farming, "#D33682" },
+                { LogLevel.Sniper, "#657b83" },
+                { LogLevel.Recycling, "#6C71C4" },
+                { LogLevel.Flee, "#B58900" },
+                { LogLevel.Transfer, "#268BD2" },
+                { LogLevel.Evolve, "#268BD2" },
+                { LogLevel.Berry, "##B58900" },
+                { LogLevel.Egg, "#B58900" },
+                { LogLevel.Debug, "#93A1A1" },
+                { LogLevel.Update, "#657b83" },
+                { LogLevel.New, "#859900" },
+                { LogLevel.SoftBan, "#DC322F" },
+                { LogLevel.LevelUp, "#D33682" },
+                { LogLevel.Gym, "#D33682" },
+                { LogLevel.Service , "#657b83" }
+        };
+
+        private static SolidColorBrush DarkSolarizedBackground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#002B36"));
+        private static SolidColorBrush LightSolarizedBackground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FDF6E3"));
+        private static SolidColorBrush ConsoleWhite = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#657b83"));
 
         public MainClientWindow()
         {
@@ -101,12 +129,22 @@ namespace PoGo.Necrobot.Window
             }
             ChangeThemeTo(Settings.Default.Theme);
             ChangeSchemeTo(Settings.Default.Scheme);
+            ConsoleThemer.ItemsSource = new List<string> { "Default", "Low Contrast (Dark)", "Low Contrast (Light)" };
+            ConsoleThemer.SelectedValue = Settings.Default.ConsoleTheme;
+            ConsoleTheming();
         }
         private DateTime lastClearLog = DateTime.Now;
         public void LogToConsoleTab(string message, LogLevel level, string color)
-        { 
-            if (string.IsNullOrEmpty(color) || color == "Black")
-                color = ConsoleColors[level];
+        {
+            if (string.IsNullOrEmpty(color) || color == "Black" & Settings.Default.ConsoleTheme != "Default")
+            {
+                if (string.IsNullOrEmpty(color) || color == "Black" & Settings.Default.ConsoleTheme == "Low Contrast (Dark)" || Settings.Default.ConsoleTheme == "Low Contrast (Light)")
+                {
+                    color = SolarizedConsoleColors[level];
+                }
+            }
+            else
+                color = DefaultConsoleColors[level];
 
             consoleLog.Dispatcher.BeginInvoke(new Action(() =>
             {
@@ -308,7 +346,7 @@ namespace PoGo.Necrobot.Window
                 }
             }
         }
-        
+
         private void BtnDonate_Click(object sender, RoutedEventArgs e)
         {
             Process.Start("http://snipe.necrobot2.com?donate");
@@ -336,7 +374,7 @@ namespace PoGo.Necrobot.Window
                         return;
 
                     var xml = await responseContent.Content.ReadAsStringAsync();
-                    
+
                     var feed = SyndicationFeed.Load(XmlReader.Create(new StringReader(xml)));
                     lastTimeLoadHelp = DateTime.Now;
 
@@ -358,7 +396,7 @@ namespace PoGo.Necrobot.Window
         private void Hyperlink_Click(object sender, RoutedEventArgs e)
         {
             var hlink = sender as Hyperlink;
-            
+
             Process.Start(hlink.NavigateUri.ToString());
             popHelpArticles.IsOpen = false;
         }
@@ -367,7 +405,7 @@ namespace PoGo.Necrobot.Window
         {
             Application.Current.Shutdown();
         }
-        
+
         private void MetroWindow_Initialized(object sender, EventArgs e)
         {
             if(SystemParameters.PrimaryScreenWidth<1366)
@@ -413,6 +451,54 @@ namespace PoGo.Necrobot.Window
         private void MetroWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
             Process.GetCurrentProcess().Kill();
+        }
+
+        private void ConsoleThemer_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            string selectedTheme = (string)ConsoleThemer.SelectedValue;
+            if (selectedTheme != "Default")
+            {
+                if (selectedTheme == "Low Contrast (Dark)")
+                {
+                    Settings.Default.ConsoleTheme = "Low Contrast (Dark)";
+                }
+                if (selectedTheme == "Low Contrast (Light)")
+                {
+                    Settings.Default.ConsoleTheme = "Low Contrast (Light)";
+                }
+            }
+            else
+            {
+                Settings.Default.ConsoleTheme = "Default";
+            }
+            ConsoleTheming();
+            Console.Clear();
+        }
+        private void ConsoleTheming()
+        {
+
+            if (Settings.Default.ConsoleTheme != "Default")
+            {
+                if (Settings.Default.ConsoleTheme == "Low Contrast (Dark)")
+                {
+                    txtCmdInput.Background = DarkSolarizedBackground;
+                    txtCmdInput.Foreground = ConsoleWhite;
+                    consoleLog.Background = DarkSolarizedBackground;
+                }
+                if (Settings.Default.ConsoleTheme == "Low Contrast (Light)")
+                {
+                    txtCmdInput.Background = LightSolarizedBackground;
+                    txtCmdInput.Foreground = ConsoleWhite;
+                    consoleLog.Background = LightSolarizedBackground;
+                }
+            }
+            else
+            {
+                txtCmdInput.Background = Brushes.Black;
+                txtCmdInput.Foreground = Brushes.White;
+                consoleLog.Background = Brushes.Black;
+            }
+            Settings.Default.Save();
         }
     }
 }

--- a/PoGo.Necrobot.Window/Properties/Settings.Designer.cs
+++ b/PoGo.Necrobot.Window/Properties/Settings.Designer.cs
@@ -58,5 +58,16 @@ namespace PoGo.Necrobot.Window.Properties {
                 this["Scheme"] = value;
             }
         }
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Default")]
+        public string ConsoleTheme {
+            get {
+                return ((string)(this["ConsoleTheme"]));
+            }
+            set {
+                this["ConsoleTheme"] = value;
+            }
+        }
     }
 }

--- a/PoGo.Necrobot.Window/Properties/Settings.settings
+++ b/PoGo.Necrobot.Window/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="Scheme" Type="System.String" Scope="User">
       <Value Profile="(Default)">BaseLight</Value>
     </Setting>
+    <Setting Name="ConsoleTheme" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Default</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
* Fix Android device variables when generating iOS

When setting auth.json DevicePackageName to "random" device is
generated, but sets android-related values to "" instead of null.  Fix
sets the five values to null on random device generation.

* Console Color Theming
Revert/Update #1520 - Default, Dark (Low Contrast), Light (Low Contrast)
Added Windows.Media (background brushes).
Second LogLevel dictionary created for Solarized themes, along with selection logic during logging.
Adds ComboBox for selection next to "Console Disable."
[Size doesn't curently adjust to text width because with HydraBuild changes, increasing default Window width seems unwise of me.]  Future PR.
Logic to select/change theme and save (persistent).

Attempted to stay consistent with pending HydraBuild changes, aside from a change similar to this one.

# Please Note (you may remove this section before opening your PR):
We receive lots of pull requests, please help us be able to review them by following the below guidelines:

1. If you are adding configuration settings, please be sure to document their usage in your description so they can be added to the wiki.
2. Make sure your code is clean and well-formed. Use comments if necessary to explain why you did something.
3. Make sure your changes are only for a specific purpose. Do not mix several changes into one pull request.
4. If the code is based off another individuals work, be sure to credit them appropriately.


## Short Description:

## Fixes (provide links to github issues if you can):
